### PR TITLE
support settings in index mappings

### DIFF
--- a/indexmanager/index_repository.go
+++ b/indexmanager/index_repository.go
@@ -74,6 +74,9 @@ func (ir *indexRepository) CreateIndex(ctx context.Context, indexName, aliasName
 	createIndexReq := map[string]interface{}{
 		"mappings": mapping.Mappings,
 	}
+	if mapping.Settings != nil {
+		createIndexReq["settings"] = mapping.Settings
+	}
 
 	if aliasName != "" {
 		createIndexReq["aliases"] = map[string]interface{}{

--- a/indexmanager/index_repository_test.go
+++ b/indexmanager/index_repository_test.go
@@ -104,6 +104,28 @@ var _ = Describe("IndexRepository", func() {
 					}),
 				}))
 			})
+
+			When("the index mapping includes settings", func() {
+				BeforeEach(func() {
+					expectedMapping.Settings = map[string]interface{}{
+						"foo": "bar",
+					}
+				})
+
+				It("should use the settings in the payload", func() {
+					actualPayload := map[string]interface{}{}
+
+					readRequestBody(mockTransport.receivedHttpRequests[1], &actualPayload)
+
+					Expect(actualPayload).To(MatchAllKeys(Keys{
+						"mappings": Equal(expectedMapping.Mappings),
+						"aliases": MatchAllKeys(Keys{
+							aliasName: BeEmpty(),
+						}),
+						"settings": Equal(expectedMapping.Settings),
+					}))
+				})
+			})
 		})
 
 		When("an unexpected status code while checking if the index exists", func() {

--- a/indexmanager/types.go
+++ b/indexmanager/types.go
@@ -60,6 +60,7 @@ type Config struct {
 type VersionedMapping struct {
 	Version  string                 `json:"version"`
 	Mappings map[string]interface{} `json:"mappings"`
+	Settings map[string]interface{} `json:"settings"`
 }
 
 type IndexName struct {


### PR DESCRIPTION
this will allow us to use features like [normalizers](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/normalizer.html) like so:

```json
{
  "settings": {
    "analysis": {
      "normalizer": {
        "my_normalizer": {
          "type": "custom",
          "char_filter": [],
          "filter": ["lowercase", "asciifolding"]
        }
      }
    }
  },
  "mappings": {
    "properties": {
      "foo": {
        "type": "keyword",
        "normalizer": "my_normalizer"
      }
    }
  }
}
```